### PR TITLE
feat: mock api request

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -29,6 +29,7 @@ import screenshot from './tools/screenshot.js';
 import testing from './tools/testing.js';
 import vision from './tools/vision.js';
 import wait from './tools/wait.js';
+import mock from './tools/mock.js';
 
 import type { Tool } from './tools/tool.js';
 
@@ -47,6 +48,8 @@ export const snapshotTools: Tool<any>[] = [
   ...tabs(true),
   ...testing,
   ...wait(true),
+
+  ...mock,
 ];
 
 export const visionTools: Tool<any>[] = [
@@ -63,4 +66,6 @@ export const visionTools: Tool<any>[] = [
   ...testing,
   ...vision,
   ...wait(false),
+
+  ...mock,
 ];

--- a/src/tools/mock.ts
+++ b/src/tools/mock.ts
@@ -1,0 +1,121 @@
+import { z } from 'zod';
+import { defineTool } from './tool.js';
+
+const mockApi = defineTool({
+  capability: 'core',
+
+  schema: {
+    name: 'browser_mock_api',
+    title: 'Mock API responses',
+    description: 'Mock API responses by intercepting network requests',
+    inputSchema: z.object({
+      url: z
+        .string()
+        .describe(
+          'URL pattern to match for interception (supports glob and regex patterns)'
+        ),
+      method: z
+        .enum(['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS'])
+        .optional()
+        .describe('HTTP method to match (ALL matches any method)'),
+      status: z
+        .number()
+        .min(100)
+        .max(599)
+        .default(200)
+        .describe('HTTP status code to return'),
+      contentType: z
+        .string()
+        .default('application/json')
+        .describe('Content-Type header for the response'),
+      body: z
+        .string()
+        .describe(
+          'Response body content (typically JSON formatted as a string)'
+        ),
+      headers: z
+        .record(z.string())
+        .optional()
+        .describe('Additional response headers to include'),
+    }),
+    type: 'readOnly',
+  },
+
+  handle: async (context, params) => {
+    const { page } = await context.ensureTab();
+
+    page.route(params.url, (route) => {
+      if (route.request().method() === params.method) {
+        route.fulfill({
+          status: params.status,
+          contentType: params.contentType,
+          body: params.body,
+          headers: params.headers,
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    const code = [
+      `// Mock API response for ${params.url}`,
+      `await page.route('${params.url}', (route, request) => {`,
+      `  if (route.request().method() === '${params.method}') {`,
+      `  route.fulfill({`,
+      `    status: ${params.status},`,
+      `    contentType: '${params.contentType}',`,
+      `    body: '${params.body}',`,
+      `    headers: {`,
+      `      ...${JSON.stringify(params.headers || {})},`,
+      `    },`,
+      `  });`,
+      `  } else {`,
+      `    route.continue();`,
+      `  }`,
+      `});`,
+    ];
+
+    return {
+      code,
+      captureSnapshot: false,
+      waitForNetwork: false,
+    };
+  },
+});
+
+const clearMockApi = defineTool({
+  capability: 'core',
+  schema: {
+    name: 'browser_clear_mock_api',
+    title: 'Clear Mock API responses',
+    description: 'Clear Mock API responses',
+    inputSchema: z.object({
+      url: z
+        .string()
+        .describe(
+          'URL pattern to remove mocking for. If not provided, all mocks will be cleared'
+        ),
+    }),
+    type: 'readOnly',
+  },
+  handle: async (context, params) => {
+    const { page } = await context.ensureTab();
+
+    if (params.url) {
+      await page.unroute(params.url);
+    }
+
+    const code = [
+      `// Clear Mock API response for ${params.url}`,
+      `await page.unroute('${params.url}');`,
+    ];
+
+    return {
+      code,
+      captureSnapshot: false,
+      waitForNetwork: false,
+    };
+  },
+});
+
+export default [mockApi, clearMockApi];


### PR DESCRIPTION
# Add API Mocking Capability to Playwright MCP


### `browser_mock_api`
- **URL Pattern Matching**: Supports glob and regex patterns for flexible request matching
- **HTTP Method Filtering**: Optional method filtering (GET, POST, PUT, DELETE, etc.)
- **Customizable Responses**: Configure status codes, content types, and response bodies
- **Header Support**: Add custom response headers
- **JSON Response Support**: Built-in support for JSON responses with proper content-type

### `browser_clear_mock_api`
- **Selective Clearing**: Remove specific mock patterns
- **Clean Teardown**: Ensure proper cleanup of mocked routes


<img width="900" alt="SCR-20250627-tebe" src="https://github.com/user-attachments/assets/73247985-2c0b-44ff-b46c-dfac1f4a3c6f" />
